### PR TITLE
(feat: ligerfusedlinearloss): support LigerFusedLinearCrossEntropyLoss for long sequnece training

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     # Stable torchdata (no nightly support)
     "torchdata",
 
+    "liger-kernel",
+
     # Hugging Face integrations
     "datasets",
     "huggingface_hub[hf_transfer]",

--- a/recipes/configs/qwen3/8B_full.yaml
+++ b/recipes/configs/qwen3/8B_full.yaml
@@ -66,6 +66,7 @@ optimizer:
   fused: True
   lr: 5e-6
 loss:
+  # _component_: torchtune.modules.loss.LigerLinearCrossEntropyLoss
   _component_: torchtune.modules.loss.LinearCrossEntropyLoss
 max_steps_per_epoch: null
 gradient_accumulation_steps: 1  # Use to increase effective batch size

--- a/torchtune/modules/loss/__init__.py
+++ b/torchtune/modules/loss/__init__.py
@@ -6,7 +6,7 @@
 
 from .ce_chunked_output_loss import CEWithChunkedOutputLoss
 
-from .cross_entropy_loss import LinearCrossEntropyLoss
+from .cross_entropy_loss import LinearCrossEntropyLoss, LigerLinearCrossEntropyLoss
 from .kd_losses import (
     ForwardKLLoss,
     ForwardKLWithChunkedOutputLoss,
@@ -26,6 +26,7 @@ __all__ = [
     "SymmetricKLLoss",
     "SymmetricKLWithChunkedOutputLoss",
     "LinearCrossEntropyLoss",
+    "LigerLinearCrossEntropyLoss",
     "SFTLoss",
     "RLLoss",
 ]


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

#### Changelog
What are the changes made in this PR?
*

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [ ] I did not change any public API
- [ ] I have added an example to docs or docstrings
